### PR TITLE
Added colours for vim indent guides

### DIFF
--- a/colors/flattown.vim
+++ b/colors/flattown.vim
@@ -122,3 +122,6 @@ hi Structure guifg=#72aaca guibg=NONE guisp=NONE gui=NONE ctermfg=110 ctermbg=NO
 hi Underlined guifg=NONE guibg=NONE guisp=NONE gui=underline ctermfg=NONE ctermbg=NONE cterm=underline
 hi DiffAdd guifg=#f8f8f8 guibg=#487a1a guisp=#487a1a gui=bold ctermfg=15 ctermbg=2 cterm=bold
 hi TabLine guifg=#797a7b guibg=#212325 guisp=#212325 gui=NONE ctermfg=8 ctermbg=235 cterm=NONE
+
+hi IndentGuidesOdd guifg=#f6f6f6 guibg=NONE guisp=NONE gui=NONE ctermfg=255 ctermbg=NONE cterm=NONE
+hi IndentGuidesEven guifg=#f8f8f8 guibg=#292c2f guisp=#292c2f gui=bold ctermfg=15 ctermbg=236


### PR DESCRIPTION
Two extra colours defined: `IndentGuidesOdd` & `IndentGuidesEven` in keeping with the general colourscheme.

[Vim indent guides](https://github.com/nathanaelkane/vim-indent-guides).
